### PR TITLE
[packaging] Fix name of gpg-error pkgconfig. JB#55771

### DIFF
--- a/rpm/libgcrypt.spec
+++ b/rpm/libgcrypt.spec
@@ -8,7 +8,7 @@ Source0: %{name}-%{version}.tar.gz
 BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: gawk
-BuildRequires: pkgconfig(libgpg-error)
+BuildRequires: pkgconfig(gpg-error)
 
 %description
 Libgcrypt is a general purpose crypto library based on the code used
@@ -16,7 +16,6 @@ in GNU Privacy Guard. This is a development version.
 
 %package devel
 Summary: Development files for the %{name} package
-Requires: pkgconfig(libgpg-error)
 Requires: %{name} = %{version}-%{release}
 
 %description devel


### PR DESCRIPTION
Now that libgpg-error pkgconfig file is fixed we don't need to
require pkgconfig(libgpg-error) for the -devel package anymore too.